### PR TITLE
Moved numRead incrementing when an 'append' is performed

### DIFF
--- a/src/ldt/lib_lstack.lua
+++ b/src/ldt/lib_lstack.lua
@@ -999,6 +999,7 @@ local function readEntryList( resultList, ldtCtrl, entryList, count )
 
     if( resultValue ~= nil ) then
       list.append( resultList, readValue );
+      numRead = numRead + 1;
     end
 
     --  This is REALLY HIGH debug output.  Turn this on ONLY if there's
@@ -1006,7 +1007,6 @@ local function readEntryList( resultList, ldtCtrl, entryList, count )
     --  GP=F and trace("[DEBUG]:<%s:%s>Appended Val(%s) to ResultList(%s)",
     --    MOD, meth, tostring( readValue ), tostring(resultList) );
     
-    numRead = numRead + 1;
     if numRead >= numToRead then
       GP=E and trace("[Early EXIT]: <%s:%s> NumRead(%d) resultListSummary(%s)",
         MOD, meth, numRead, ldt_common.summarizeList( resultList ));


### PR DESCRIPTION
There is a bug in lstack.filter() when a filter is being applied. The `numRead` variable is being incremented no matter if the filter returned an object or nil. Thus when trying to read first 100 values matching a filter predicate - only the first 100 items in the stack are scanned. Expected - the stack to be continuosly scanned until 100 values matching the filter predicate are found.