### PR TITLE
remove  a non-exist key should set rc to not found

### DIFF
--- a/src/ldt/lib_llist.lua
+++ b/src/ldt/lib_llist.lua
@@ -5446,6 +5446,8 @@ local function localDelete(topRec, ldtCtrl, key, src)
     if (resultMap.Status == ERR.OK and resultMap.Found) then
       ldtMap[LS.CompactList] =
         ldt_common.listDelete(objectList, resultMap.Position);
+    else
+        rc = ERR.NOT_FOUND;
     end
   else
     rc = treeDelete(src, topRec, ldtCtrl, key);


### PR DESCRIPTION
Delete should handle removing a non-exist key to make sure the list.size() work correctly.