### PR TITLE
Add loadstring function to the sandboxed environment

### DIFF
--- a/src/aerospike.lua
+++ b/src/aerospike.lua
@@ -83,6 +83,7 @@ function env_record()
         ["getmetatable"] = getmetatable,
         ["ipairs"] = ipairs,
         ["load"] = load,
+        ["loadstring"] = loadstring,
         ["module"] = module,
         ["next"] = next,
         ["pairs"] = pairs,


### PR DESCRIPTION
Loadstring function can be helpful in dynamically creating filter function based on user provided arguments, so it could be byte compiled only once per function call (instead checking parameters per each record).
function my_filter(stream, condstr)
  local filter_function, errstr = loadstring('return function(rec) return '..condstr..' end')
  local filter, mapper
  if filter_function then
    filter=filter_function()
  end
  return stream : filter (filter) : map (mapper)
end
-- call with: aggregate test.my_filter('(rec.name=="John" or rec.name=="Bill") and rec.city=="London")') on test.people where country=='UK'